### PR TITLE
Solves bug with constant embedding matrix

### DIFF
--- a/model/model_builder.py
+++ b/model/model_builder.py
@@ -70,10 +70,10 @@ class ModelBuilder(object):
 
         # Embedding matrix for the words
         embedding_matrix = tf.Variable(
-            tf.constant(0.0,
-                        shape=[self._model.vocabulary_size,
-                               self._model.embedding_size],
-                        dtype=tf.float64),
+            tf.random_uniform(
+                [self._model.vocabulary_size,
+                 self._model.embedding_size],
+                -1.0, 1.0, dtype=tf.float64),
             trainable=self._model.is_trainable_matrix,
             name="embedding_matrix",
             dtype=tf.float64)


### PR DESCRIPTION
This should fix the bug mentioned in #17 . The embedding matrix is not initialized using a uniform random distribution between [-1, 1], as [done here](https://www.tensorflow.org/tutorials/word2vec). If `use_pretrained` is set to `true` this random embedding matrix will be overwritten with the pre-trained one.